### PR TITLE
An objectifying proposal

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -21,7 +21,7 @@ def create_event(db:Session, event:schemas.EventCreate):
     db.commit()
     db.refresh(db_event)
 
-    slug = f"{db_event.id}/{slugify(event.title)}"
+    slug = f"{slugify(event.title)}"
 
     db_event.slug = slug
     db.commit()


### PR DESCRIPTION
Adds a redirect route to permit /api/v1/events/{event_id} AND /api/v1/events/{event_id}/{event_name} - the URL will always be human-readable, but the event_name isn't necessary

Also adjusted the slug creation logic (again lol) because the previous slug stored in the db included the event ID

this means that the fresh routes won't always work for events that were created with the older slug logic! but it'll clear itself out eventually

We can drop this and go back to a simpler way - feedback super welcome.