### PR TITLE
Adjust qa responses

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -170,7 +170,7 @@ def create_qa(event_id: int, qa_data: schemas.QACreate, request: Request, db: Se
         db.add(db_post)
         db.commit()
         db.refresh(db_post)
-        return db_post
+        return schemas.QAResponse.model_validate(db_post)
 
     except ValueError as e:
         return JSONResponse(

--- a/app/main.py
+++ b/app/main.py
@@ -156,13 +156,13 @@ def create_qa(event_id: int, qa_data: schemas.QACreate, request: Request, db: Se
             db_post = models.Question(event_id=event_id, question_text=qa_data.question_text)
         
         elif qa_data.answer_text:
-            if not qa_data.question_id:
-                raise ValueError("question_id is required for answers.")
-            question = db.query(models.Question).filter(models.Question.id == qa_data.question_id)
-            if question is None:
+            if not qa_data.id:
+                raise ValueError("question id is required to post answers.")
+            question = db.query(models.Question).filter(models.Question.id == qa_data.id).first()
+            if not question:
                 raise ValueError("Question not found")
 
-            db_post = models.Answer(question_id=qa_data.question_id, answer_text=qa_data.answer_text)
+            db_post = models.Answer(id=qa_data.id, answer_text=qa_data.answer_text)
 
         else:
             raise ValueError("Either question_text or answer_text must be provided.")
@@ -170,7 +170,8 @@ def create_qa(event_id: int, qa_data: schemas.QACreate, request: Request, db: Se
         db.add(db_post)
         db.commit()
         db.refresh(db_post)
-        return schemas.QAResponse.model_validate(db_post)
+
+        return db_post
 
     except ValueError as e:
         return JSONResponse(

--- a/app/main.py
+++ b/app/main.py
@@ -96,6 +96,10 @@ def get_event(
         if event_name is None or event_name != event.event.slug:
             return RedirectResponse(url=f"/api/v1/events/{event.event.event_id}/{event.event.slug}", status_code=307)
 
+        for question in event.questions or []:
+            if question.answers is None:
+                question.answers = []
+                
         return event
 
     except Exception as e:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -76,13 +76,13 @@ class QuestionResponse(BaseModel):
     id: int
     question_text: str
     created_at: dt
-    answers: Optional[List[AnswerResponse]] = None
+    answers: Optional[List[AnswerResponse]] = []
 
     model_config = ConfigDict(from_attributes=True, extra="ignore")
 
 class EventResponse(BaseModel):
     event: EventData
     location: Optional[Location] = None
-    questions: Optional[List[QuestionResponse]] = None
+    questions: Optional[List[QuestionResponse]] = []
 
     model_config = ConfigDict(from_attributes = True, extra = "ignore")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -65,21 +65,12 @@ class QACreate(BaseModel):
     question_text: Optional[str] = None  # Present if creating a question
     answer_text: Optional[str] = None  # Present if creating an answer
 
-class QAResponse(BaseModel):
-    id: int # QUESTION id
-    event_id: Optional[int] = None
-    question_text: Optional[str] = None
-    answer_text: Optional[str] = None
-    created_at: dt
-
-    model_config = ConfigDict(from_attributes=True)
-
 class AnswerResponse(BaseModel):
     id: int
     answer_text: str
     created_at: dt
 
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+    model_config = ConfigDict(from_attributes=True, extra="ignore")
 
 class QuestionResponse(BaseModel):
     id: int
@@ -87,7 +78,7 @@ class QuestionResponse(BaseModel):
     created_at: dt
     answers: Optional[List[AnswerResponse]] = None
 
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+    model_config = ConfigDict(from_attributes=True, extra="ignore")
 
 class EventResponse(BaseModel):
     event: EventData

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -61,7 +61,7 @@ class EventData(BaseModel):
     model_config = ConfigDict(from_attributes=True, populate_by_name=True, extra="ignore")
 
 class QACreate(BaseModel):
-    question_id: Optional[int] = None  # Required for answers
+    id: Optional[int] = None  # QUESTION id - Required for answers
     question_text: Optional[str] = None  # Present if creating a question
     answer_text: Optional[str] = None  # Present if creating an answer
 
@@ -76,14 +76,14 @@ class QAResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 class AnswerResponse(BaseModel):
-    id: int = Field(..., alias="answer_id")
+    id: int
     answer_text: str
     created_at: dt
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 class QuestionResponse(BaseModel):
-    id: int = Field(..., alias="question_id")
+    id: int
     question_text: str
     created_at: dt
     answers: Optional[List[AnswerResponse]] = None

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -66,9 +66,8 @@ class QACreate(BaseModel):
     answer_text: Optional[str] = None  # Present if creating an answer
 
 class QAResponse(BaseModel):
-    id: int
+    id: int # QUESTION id
     event_id: Optional[int] = None
-    question_id: Optional[int] = None
     question_text: Optional[str] = None
     answer_text: Optional[str] = None
     created_at: dt

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+python_files = tests/test_*.py
+asyncio_default_fixture_loop_scope = function

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest==8.3.4
+pytest-asyncio==0.25.3
+pluggy==1.5.0
+iniconfig==2.0.0
+httpx==0.27.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,31 +1,29 @@
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from app.database import Base, get_db
-from app.models import Event, Location, Question
+from app.database import Base, SessionLocal
+from app.main import app, get_db
+from fastapi.testclient import TestClient
 
-# Create a temporary SQLite database for testing
+
 TEST_DATABASE_URL = "sqlite:///:memory:"
 engine = create_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-# Fixture to set up the database
 @pytest.fixture(scope="function")
 def db():
     """Creates a new database session for each test."""
-    Base.metadata.create_all(bind=engine)  # Create tables
-    db = TestingSessionLocal()
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
     try:
-        yield db  # Provide the test database session
+        yield session
     finally:
-        db.close()
-        Base.metadata.drop_all(bind=engine)  # Clean up tables after test
+        session.rollback()
+        session.close()
+        Base.metadata.drop_all(bind=engine)
 
-# Override FastAPI dependency for tests
 @pytest.fixture(scope="function")
-def client():
-    from fastapi.testclient import TestClient
-    from app.main import app
-
-    app.dependency_overrides[get_db] = lambda: db()
-    return TestClient(app)
+def client(db):
+   """Provides a FastAPI test client with a fresh DB session"""
+   app.dependency_overrides[get_db] = lambda: db
+   return TestClient(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.database import Base, get_db
+from app.models import Event, Location, Question
+
+# Create a temporary SQLite database for testing
+TEST_DATABASE_URL = "sqlite:///:memory:"
+engine = create_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Fixture to set up the database
+@pytest.fixture(scope="function")
+def db():
+    """Creates a new database session for each test."""
+    Base.metadata.create_all(bind=engine)  # Create tables
+    db = TestingSessionLocal()
+    try:
+        yield db  # Provide the test database session
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)  # Clean up tables after test
+
+# Override FastAPI dependency for tests
+@pytest.fixture(scope="function")
+def client():
+    from fastapi.testclient import TestClient
+    from app.main import app
+
+    app.dependency_overrides[get_db] = lambda: db()
+    return TestClient(app)

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,107 +1,16 @@
-from app.crud import create_event
-from app.schemas import EventCreate
+from app import crud, models, schemas
+from datetime import datetime
 
 def test_create_event(db):
-    event_data = EventCreate(
+    """Test creating an event in the database"""
+    event_data = schemas.EventCreate(
         title="Test Event",
-        startDateTime="2025-01-01T10:00:00",
-        endDateTime="2025-01-01T12:00:00",
-        description="This is a test event.",
-        isShareable=True,
-        allowQA=True,
-        location={"placeId": "12345", "name": "Test Location", "city": "Test City", "state": "TS", "postcode": "12345"}
+        start_date_time="2025-01-01T10:00:00"
     )
 
-    event = create_event(db, event_data)
+    event = crud.create_event(db, event_data)
 
-    assert event.id is not None
-    assert event.title == "Test Event"
-    assert event.slug.startswith(f"{event.id}/test-event")
-
-from app.crud import get_events
-
-def test_get_events(db):
-    events = get_events(db)
-    assert isinstance(events, list)
-
-from app.crud import get_event_by_id
-
-def test_get_event_by_id(db):
-    event = get_event_by_id(db, 1)
-    assert event is None  # No event should exist initially
-
-"""from app.crud import update_event
-from app.schemas import EventUpdate
-
-def test_update_event(db):
-    # Create an event first
-    event_data = EventCreate(
-        title="Original Title",
-        startDateTime="2025-01-01T10:00:00",
-        endDateTime="2025-01-01T12:00:00",
-        description="Original Description",
-        isShareable=True,
-        allowQA=True,
-        location={"placeId": "12345", "name": "Test Location", "city": "Test City", "state": "TS", "postcode": "12345"}
-    )
-    event = create_event(db, event_data)
-
-    # Update the event title
-    update_data = EventUpdate(title="Updated Title")
-    updated_event = update_event(db, event.id, update_data)
-
-    assert updated_event.title == "Updated Title"
-
-from app.crud import delete_event
-
-def test_delete_event(db):
-    event_data = EventCreate(
-        title="Event to Delete",
-        startDateTime="2025-01-01T10:00:00",
-        endDateTime="2025-01-01T12:00:00",
-        description="This will be deleted.",
-        isShareable=True,
-        allowQA=True,
-        location={"placeId": "12345", "name": "Test Location", "city": "Test City", "state": "TS", "postcode": "12345"}
-    )
-    event = create_event(db, event_data)
-
-    deleted_event = delete_event(db, event.id)
-
-    assert deleted_event is not None
-    assert delete_event(db, event.id) is None  # Should return None after deletion
-
-from app.crud import get_or_create_location
-from app.schemas import LocationBase
-
-def test_get_or_create_location(db):
-    location_data = LocationBase(
-        placeId="12345",
-        name="Test Location",
-        addressLine1="123 Test St",
-        city="Test City",
-        state="TS",
-        postcode="12345"
-    )
-
-    location_id_1 = get_or_create_location(db, location_data)
-    location_id_2 = get_or_create_location(db, location_data)
-
-    assert location_id_1 == location_id_2  # It should return the same location ID
-
-from app.crud import create_question
-from app.schemas import QuestionCreate
-
-def test_create_question(db):
-    question_data = QuestionCreate(event_id=1, text="What is this event about?")
-    question = create_question(db, question_data)
-
-    assert question.id is not None
-    assert question.text == "What is this event about?"
-
-from app.crud import get_questions_by_event
-
-def test_get_questions_by_event(db):
-    questions = get_questions_by_event(db, 1)
-    assert isinstance(questions, list)
-"""
+    assert event.event.event_id is not None
+    assert event.event.title == "Test Event"
+    assert event.event.start_date_time == datetime.fromisoformat("2025-01-01T10:00:00")
+    assert event.location is None

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,0 +1,107 @@
+from app.crud import create_event
+from app.schemas import EventCreate
+
+def test_create_event(db):
+    event_data = EventCreate(
+        title="Test Event",
+        startDateTime="2025-01-01T10:00:00",
+        endDateTime="2025-01-01T12:00:00",
+        description="This is a test event.",
+        isShareable=True,
+        allowQA=True,
+        location={"placeId": "12345", "name": "Test Location", "city": "Test City", "state": "TS", "postcode": "12345"}
+    )
+
+    event = create_event(db, event_data)
+
+    assert event.id is not None
+    assert event.title == "Test Event"
+    assert event.slug.startswith(f"{event.id}/test-event")
+
+from app.crud import get_events
+
+def test_get_events(db):
+    events = get_events(db)
+    assert isinstance(events, list)
+
+from app.crud import get_event_by_id
+
+def test_get_event_by_id(db):
+    event = get_event_by_id(db, 1)
+    assert event is None  # No event should exist initially
+
+"""from app.crud import update_event
+from app.schemas import EventUpdate
+
+def test_update_event(db):
+    # Create an event first
+    event_data = EventCreate(
+        title="Original Title",
+        startDateTime="2025-01-01T10:00:00",
+        endDateTime="2025-01-01T12:00:00",
+        description="Original Description",
+        isShareable=True,
+        allowQA=True,
+        location={"placeId": "12345", "name": "Test Location", "city": "Test City", "state": "TS", "postcode": "12345"}
+    )
+    event = create_event(db, event_data)
+
+    # Update the event title
+    update_data = EventUpdate(title="Updated Title")
+    updated_event = update_event(db, event.id, update_data)
+
+    assert updated_event.title == "Updated Title"
+
+from app.crud import delete_event
+
+def test_delete_event(db):
+    event_data = EventCreate(
+        title="Event to Delete",
+        startDateTime="2025-01-01T10:00:00",
+        endDateTime="2025-01-01T12:00:00",
+        description="This will be deleted.",
+        isShareable=True,
+        allowQA=True,
+        location={"placeId": "12345", "name": "Test Location", "city": "Test City", "state": "TS", "postcode": "12345"}
+    )
+    event = create_event(db, event_data)
+
+    deleted_event = delete_event(db, event.id)
+
+    assert deleted_event is not None
+    assert delete_event(db, event.id) is None  # Should return None after deletion
+
+from app.crud import get_or_create_location
+from app.schemas import LocationBase
+
+def test_get_or_create_location(db):
+    location_data = LocationBase(
+        placeId="12345",
+        name="Test Location",
+        addressLine1="123 Test St",
+        city="Test City",
+        state="TS",
+        postcode="12345"
+    )
+
+    location_id_1 = get_or_create_location(db, location_data)
+    location_id_2 = get_or_create_location(db, location_data)
+
+    assert location_id_1 == location_id_2  # It should return the same location ID
+
+from app.crud import create_question
+from app.schemas import QuestionCreate
+
+def test_create_question(db):
+    question_data = QuestionCreate(event_id=1, text="What is this event about?")
+    question = create_question(db, question_data)
+
+    assert question.id is not None
+    assert question.text == "What is this event about?"
+
+from app.crud import get_questions_by_event
+
+def test_get_questions_by_event(db):
+    questions = get_questions_by_event(db, 1)
+    assert isinstance(questions, list)
+"""

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -2,7 +2,7 @@ from app import crud, models, schemas
 from datetime import datetime
 
 def test_create_event(db):
-    """Test creating an event in the database"""
+    """Test creating an event in the database, minimum required data"""
     event_data = schemas.EventCreate(
         title="Test Event",
         start_date_time="2025-01-01T10:00:00"
@@ -14,3 +14,136 @@ def test_create_event(db):
     assert event.event.title == "Test Event"
     assert event.event.start_date_time == datetime.fromisoformat("2025-01-01T10:00:00")
     assert event.location is None
+
+def test_create_event_with_existing_location(db):
+    """Test creating an event using an existing location"""
+    location_id = crud.get_or_create_location(db, schemas.LocationBase(
+        place_id="existing-place-123",
+        full_address="789 Old St, Existing City, TS 56789",
+        address_1="789 Old St",
+        city="Existing City",
+        state="TS",
+        zip="56789"
+    ))
+
+    event_data = schemas.EventCreate(
+        title="Event with existing location",
+        start_date_time="2025-01-01T10:00:00",
+        location_id=location_id
+    )
+
+    event = crud.create_event(db, event_data)
+
+    assert event.event.event_id is not None
+    assert event.event.title == "Event with existing location"
+    assert event.location.id == location_id
+    assert event.location is not None
+
+def test_create_event_with_new_location(db):
+    """Test creating an event and a new location together"""
+    event_data = schemas.EventCreate(
+        title="Event with new location",
+        start_date_time="2025-01-01T10:00:00",
+        location=schemas.LocationBase(
+            place_id="new-place-456",
+            full_address="456 New St, New City, TS 67890",
+            address_1="456 New St",
+            city="New City",
+            state="TS",
+            zip="67890"
+        )
+    )
+
+    event = crud.create_event(db, event_data)
+
+    assert event.event.event_id is not None
+    assert event.event.title == "Event with new location"
+
+    assert event.location is not None
+    assert event.location.full_address == "456 New St, New City, TS 67890"
+    assert event.location.place_id == "new-place-456"
+
+def test_get_event_by_id(db):
+    """Test retrieving an event by its ID"""
+    event_data = schemas.EventCreate(
+        title="Test Event",
+        start_date_time="2025-01-01T10:00:00",
+        location=schemas.LocationBase(
+            place_id="test-place-789",
+            full_address="789 Test Ave, Sample City, TS 67890",
+            address_1="789 Test Ave",
+            city="Sample City",
+            state="TS",
+            zip="67890"
+        )
+    )
+
+    created_event = crud.create_event(db, event_data)
+
+    fetched_event = crud.get_event_by_id(db, created_event.event.event_id)
+
+    assert fetched_event is not None
+    assert fetched_event.event.event_id == created_event.event.event_id
+    assert fetched_event.event.title == "Test Event"
+    assert fetched_event.event.start_date_time == created_event.event.start_date_time
+
+    assert fetched_event.location is not None
+    assert fetched_event.location.full_address == "789 Test Ave, Sample City, TS 67890"
+
+def test_get_non_existent_event_by_id(db):
+    """Test retrieving an event that does not exist"""
+    non_existent_event_id = 9999  # Assuming this doesn't exist
+
+    fetched_event = crud.get_event_by_id(db, non_existent_event_id)
+
+    assert fetched_event is None
+
+def test_get_or_create_location_creates_new_location(db):
+    """Test that get_or_create_location creates a new location when it doesn't exist"""
+    location_data = schemas.LocationBase(
+        place_id="new-place-123",
+        full_address="123 Test St, Testville, TS 12345",
+        address_1="123 Test St",
+        city="Testville",
+        state="TS",
+        zip="12345"
+    )
+
+    location_id = crud.get_or_create_location(db, location_data)
+
+    assert location_id is not None
+    location = db.query(models.Location).filter(models.Location.id == location_id).first()
+    assert location is not None
+    assert location.full_address == "123 Test St, Testville, TS 12345"
+
+def test_get_or_create_location_retrieves_existing_location(db):
+    """Test that get_or_create_location retrieves an existing location instead of creating a new one"""
+    existing_location = models.Location(
+        place_id="existing-place-789",
+        name="Existing Test Location",
+        full_address="456 Old St, Sample City, TS 67890",
+        address_1="456 Old St",
+        city="Sample City",
+        state="TS",
+        zip="67890"
+    )
+    db.add(existing_location)
+    db.commit()
+    db.refresh(existing_location)
+
+    location_data = schemas.LocationBase(
+        place_id="existing-place-789",
+        full_address="456 Old St, Sample City, TS 67890",
+        address_1="456 Old St",
+        city="Sample City",
+        state="TS",
+        zip="67890"
+    )
+
+    location_id = crud.get_or_create_location(db, location_data)
+
+    assert location_id == existing_location.id
+
+#test_create_event_with_invalid_location
+#test_create_event_without_title
+#test_get_event_with_invalid_location

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,33 +1,94 @@
 from fastapi.testclient import TestClient
 from app.main import app
+from app import schemas, crud, models
 
 client = TestClient(app)
 
-def test_read_events():
-    response = client.get("/api/v1/events/")
+def test_post_create_event():
+    """Test creating an event via FastAPI route"""
+    response = client.post("/api/v1/events/", json={
+        "title": "API Test Event",
+        "start_date_time": "2025-01-01T10:00:00"
+    })
+
+    assert response.status_code == 201
+    data = response.json()
+
+    assert "data" in data
+    assert "event" in data["data"]
+    assert "event_id" in data["data"]["event"]
+    assert data["data"]["event"]["title"] == "API Test Event"
+
+def test_get_event_by_id():
+    """Test retrieving an event by ID, including questions and answers"""
+    
+    create_response = client.post("/api/v1/events/", json={
+        "title": "Event with QA",
+        "start_date_time": "2025-01-01T10:00:00",
+        "allow_qa": True
+    })
+
+    assert create_response.status_code == 201
+    data = create_response.json()
+
+    assert "data" in data
+    assert "event" in data["data"]
+    event_id = data["data"]["event"]["event_id"]
+    
+    response = client.get(f"/api/v1/events/{event_id}")
+
     assert response.status_code == 200
     data = response.json()
+
+    assert "event" in data
+    assert data["event"]["title"] == "Event with QA"
+
+    assert "questions" in data
+    assert isinstance(data["questions"], list)
+
+def test_get_event_by_id_and_slug():
+    """Test retrieving an event by ID and slug"""
     
-    assert isinstance(data, list)
-    assert len(data) > 0
+    create_response = client.post("/api/v1/events/", json={
+        "title": "Slugged Event",
+        "start_date_time": "2025-01-01T10:00:00",
+        "allow_qa": True
+    })
 
-    first_event = data[0]
-    assert "title" in first_event
-    assert "startDateTime" in first_event
-    assert "location" in first_event
-    assert isinstance(first_event["location"], dict)
+    assert create_response.status_code == 201
+    data = create_response.json()
 
-#CRUD tests
-#Create
-#Read list
-#Read single item
-#Update
-#Delete
+    event_id = data["data"]["event"]["event_id"]
+    event_slug = data["data"]["event"]["slug"]
 
-#Edge cases/validations
+    response = client.get(f"/api/v1/events/{event_id}/{event_slug}")
 
-#Authentication/authorization
+    assert response.status_code == 200
+    data = response.json()
 
-#Performance/load
+    assert "event" in data
+    assert data["event"]["id"] == event_id
+    assert data["event"]["slug"] == event_slug
 
-#Error handling
+def test_post_question():
+    """Test posting a question to an event"""
+
+    create_response = client.post("/api/v1/events/", json={
+        "title": "QA Event",
+        "start_date_time": "2025-01-01T10:00:00",
+        "allow_qa": True
+    })
+    assert create_response.status_code == 201
+    event_id = create_response.json()["data"]["event"]["id"]
+
+    question_response = client.post(f"/api/v1/events/{event_id}/qa", json={
+        "question_text": "Can I bring my cat?"
+    })
+
+    assert question_response.status_code == 200
+    data = question_response.json()
+
+    assert "id" in data
+    assert data["question_text"] == "Can I bring my cat?"
+
+#test_post_answer

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_read_events():
+    response = client.get("/api/v1/events/")
+    assert response.status_code == 200
+    data = response.json()
+    
+    assert isinstance(data, list)
+    assert len(data) > 0
+
+    first_event = data[0]
+    assert "title" in first_event
+    assert "startDateTime" in first_event
+    assert "location" in first_event
+    assert isinstance(first_event["location"], dict)
+
+#CRUD tests
+#Create
+#Read list
+#Read single item
+#Update
+#Delete
+
+#Edge cases/validations
+
+#Authentication/authorization
+
+#Performance/load
+
+#Error handling


### PR DESCRIPTION
consistent use of "id", no more messing around with question_id aliasing
dynamically use QuestionResponse/AnswerResponse depending on what data is being submitted on the create_qa route
return empty array for unanswered questions
messy rebase history, probably fine